### PR TITLE
Read only YAML files in a directory.

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -70,6 +70,10 @@ func ReadPromptsInDir(dirname string) (map[string]*Prompt, error) {
 		if file.IsDir() {
 			continue
 		}
+		// skip non-yaml files
+		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
+			continue
+		}
 		prompt, err := NewPromptFromFile(dirname + "/" + file.Name())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This diff adds a check to skip non-YAML files when reading prompts from a directory.
This ensures that only YAML files are read and processed.
