### PR TITLE
Add support for reading OpenAI API key from a YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ a location with a PATH.
 
 ## Prerequisite
 
-You need to set the API Key in the OPENAI_API_KEY environment variable.
+You need to set the API Key in `$HOME/.aichat/credentials.yml`:
+
+```yaml
+openai_api_key: YOUR_API_KEY
+```
+
+Or set as OPENAI_API_KEY environment variable.
 
 ## How to use
 

--- a/aichat.go
+++ b/aichat.go
@@ -101,9 +101,9 @@ func main() {
 		return
 	}
 
-	openaiAPIKey := os.Getenv("OPENAI_API_KEY")
-	if openaiAPIKey == "" {
-		log.Fatal("OPENAI_API_KEY is not set")
+	openaiAPIKey, err := ReadOpenAIAPIKey()
+	if err != nil {
+		log.Fatal(err)
 	}
 	options := chatOptions{
 		temperature: temperature,

--- a/credential.go
+++ b/credential.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type Credentials struct {
+	OpenAIAPIKey string `yaml:"openai_api_key"`
+}
+
+func ReadOpenAIAPIKey() (string, error) {
+	// first try to read from env
+	key, found := os.LookupEnv("OPENAI_API_KEY")
+	if found {
+		return key, nil
+	}
+	// then try to read from ~/.aichat/credentials.yml
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(homedir, ".aichat", "credentials.yml")
+	// check permission and warn if its too open
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&0077 != 0 {
+		log.Printf("WARN: credentials file %s has too open permission\n", path)
+	}
+	credentials := &Credentials{}
+	if err := ReadYamlFromFile(path, credentials); err != nil {
+		return "", err
+	}
+	return credentials.OpenAIAPIKey, nil
+}


### PR DESCRIPTION
This commit adds support for reading the OpenAI API key from a YAML file located at `$HOME/.aichat/credentials.yml`.
If the file exists and is readable, the API key will be read from it. If the file does not exist or is not readable,
the program will fall back to reading the API key from the `OPENAI_API_KEY` environment variable.
If the API key is not set in either location, the program will exit with an error message.
