### PR TITLE
Add error handling for empty response in AI chatbot

### DIFF
--- a/aichat.go
+++ b/aichat.go
@@ -41,6 +41,9 @@ func streamCompletion(client *gogpt.Client, request gogpt.ChatCompletionRequest,
 		if err != nil {
 			return fmt.Errorf("stream recv: %w", err)
 		}
+		if len(response.Choices) == 0 {
+			return fmt.Errorf("no choices returned")
+		}
 		_, err = fmt.Fprint(out, response.Choices[0].Delta.Content)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit adds an error handling for empty response in the AI chatbot.
If the response from the server does not contain any choices, the program will return an error message.

Fixes #16
