### PR TITLE
Add token limit for GPT models and update prompt token limit calculation

### DIFF
--- a/aichat_test.go
+++ b/aichat_test.go
@@ -17,3 +17,19 @@ func TestCountTokens(t *testing.T) {
 		t.Errorf("CountTokens() returned %d, expected 8", count)
 	}
 }
+
+func TestTokenLimitOfModel(t *testing.T) {
+	data := []struct {
+		modelName  string
+		tokenLimit int
+	}{
+		{"gpt-3.5-turbo", 4096},
+		{"gpt-4", 8192},
+	}
+	for _, d := range data {
+		tokenLimit := tokenLimitOfModel(d.modelName)
+		if tokenLimit != d.tokenLimit {
+			t.Errorf("TokenLimitForModel(%q) returned %d, expected %d", d.modelName, tokenLimit, d.tokenLimit)
+		}
+	}
+}

--- a/prompt.go
+++ b/prompt.go
@@ -87,14 +87,14 @@ func countMessagesTokens(encoder *tokenizer.Encoder, messages []Message) (int, e
 }
 
 // AllowedInputTokens returns the number of tokens allowed for the input
-func (p *Prompt) AllowedInputTokens(encoder *tokenizer.Encoder, maxTokensOverride int, verbose bool) (int, error) {
+func (p *Prompt) AllowedInputTokens(encoder *tokenizer.Encoder, tokenLimit, maxTokensOverride int, verbose bool) (int, error) {
 	promptTokens, err := p.CountTokens(encoder)
 	if err != nil {
 		return 0, err
 	}
 	// reserve 500 tokens for output if maxTokens is not specified
 	maxTokens := firstNonZeroInt(maxTokensOverride, p.MaxTokens, 500)
-	result := 4096 - (promptTokens + maxTokens)
+	result := tokenLimit - (promptTokens + maxTokens)
 	if verbose {
 		log.Printf("allowed tokens for input is %d", result)
 	}
@@ -104,14 +104,14 @@ func (p *Prompt) AllowedInputTokens(encoder *tokenizer.Encoder, maxTokensOverrid
 	return result, nil
 }
 
-func (p *Prompt) AllowedSubsequentInputTokens(encoder *tokenizer.Encoder, outputLen, maxTokensOverride int, verbose bool) (int, error) {
+func (p *Prompt) AllowedSubsequentInputTokens(encoder *tokenizer.Encoder, outputLen, tokenLimit, maxTokensOverride int, verbose bool) (int, error) {
 	promptTokens, err := p.CountSubsequentTokens(encoder)
 	if err != nil {
 		return 0, err
 	}
 	// reserve 500 tokens for output if maxTokens is not specified
 	maxTokens := firstNonZeroInt(maxTokensOverride, p.MaxTokens, 500)
-	result := 4096 - (promptTokens + maxTokens + outputLen)
+	result := tokenLimit - (promptTokens + maxTokens + outputLen)
 	if verbose {
 		log.Printf("allowed tokens for subsequent input is %d", result)
 	}
@@ -145,8 +145,8 @@ func splitStringWithTokensLimit(s string, tokensLimit int) ([]string, error) {
 	return parts, nil
 }
 
-func (p *Prompt) CreateMessagesWithSplit(encoder *tokenizer.Encoder, input string, maxTokensOverride int, verbose bool) ([][]gogpt.ChatCompletionMessage, error) {
-	allowedInputTokens, err := p.AllowedInputTokens(encoder, maxTokensOverride, verbose)
+func (p *Prompt) CreateMessagesWithSplit(encoder *tokenizer.Encoder, input string, tokenLimit, maxTokensOverride int, verbose bool) ([][]gogpt.ChatCompletionMessage, error) {
+	allowedInputTokens, err := p.AllowedInputTokens(encoder, tokenLimit, maxTokensOverride, verbose)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit adds a function to calculate the maximum token limit for a given
GPT model. It also updates the `AllowedInputTokens` and
`AllowedSubsequentInputTokens` functions to use the token limit instead of
hardcoding the value to 4096. Additionally, the `CreateMessagesWithSplit`
function is updated to use the new `AllowedInputTokens` function signature.
Finally, a new test function is added to test the `tokenLimitOfModel` function.
