### PR TITLE
Improve logging of messages in aichat.go

### DIFF
--- a/aichat.go
+++ b/aichat.go
@@ -308,7 +308,7 @@ func main() {
 		} else {
 			messages := prompt.CreateMessages(input)
 			if verbose {
-				log.Printf("messages: %+v", messagesSlice)
+				log.Printf("messages: %+v", messages)
 			}
 			messagesSlice = [][]gogpt.ChatCompletionMessage{messages}
 		}


### PR DESCRIPTION
- Replace incorrect variable name `messagesSlice` with `messages` in log.Printf statement
